### PR TITLE
Add debug log to trace config AP issue

### DIFF
--- a/dom/system/gonk/NetworkManager.js
+++ b/dom/system/gonk/NetworkManager.js
@@ -115,7 +115,7 @@ const CONNECTION_TYPE_WIFI      = 3;
 const CONNECTION_TYPE_OTHER     = 4;
 const CONNECTION_TYPE_NONE      = 5;
 
-let DEBUG = false;
+let DEBUG = true;
 
 // Read debug setting from pref.
 try {

--- a/dom/system/gonk/NetworkService.js
+++ b/dom/system/gonk/NetworkService.js
@@ -35,7 +35,7 @@ const WIFI_CTRL_INTERFACE = "wl0.1";
 
 const MANUAL_PROXY_CONFIGURATION = 1;
 
-let DEBUG = false;
+let DEBUG = true;
 
 // Read debug setting from pref.
 try {

--- a/dom/system/gonk/NetworkUtils.cpp
+++ b/dom/system/gonk/NetworkUtils.cpp
@@ -27,7 +27,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>  // inet_ntop()
 
-#define _DEBUG 0
+#define _DEBUG 1
 
 #define WARN(args...)   __android_log_print(ANDROID_LOG_WARN,  "NetworkUtils", ## args)
 #define ERROR(args...)  __android_log_print(ANDROID_LOG_ERROR,  "NetworkUtils", ## args)


### PR DESCRIPTION
Sometimes the dongle cannot enter into AP mode. Add those debug log which should be reverted later.

Signed-off-by: Jianmin Zhou toandrew@infthink.com
