### PR TITLE
Fix large media file(>=4G) cannot play issue.

### DIFF
--- a/content/media/MediaCache.cpp
+++ b/content/media/MediaCache.cpp
@@ -2425,8 +2425,15 @@ nsresult MediaCacheStream::GetCachedRanges(nsTArray<MediaByteRange>& aRanges)
     // Bytes [startOffset..endOffset] are cached.
     aRanges.AppendElement(MediaByteRange(startOffset, endOffset));
     startOffset = GetNextCachedData(endOffset);
+
+    // assert?
     NS_ASSERTION(startOffset == -1 || startOffset > endOffset,
       "Must have advanced to start of next range, or hit end of stream");
+
+    if (startOffset == -1 || startOffset <= endOffset) {
+        printf_stderr("MediaCacheStream::GetCachedRanges: maybe in dead loop? directly return?!!!!");
+        break;
+    }
   }
   return NS_OK;
 }

--- a/content/media/VideoUtils.cpp
+++ b/content/media/VideoUtils.cpp
@@ -101,6 +101,11 @@ void GetEstimatedBufferedTimeRanges(mozilla::MediaResource* aStream,
                         double(endUs) / USECS_PER_S);
     }
     startOffset = aStream->GetNextCachedData(endOffset);
+
+    // should be assert?
+    if (startOffset == -1 || startOffset <= endOffset) {
+        break;
+    }
   }
   return;
 }


### PR DESCRIPTION
There's a dead loop when trying to get current cache buffer status. Need unlock it in some conditions.
But it's only a WA. Need dig more to found the root cause of this kind of cache issue.

Signed-off-by: Jianmin Zhou toandrew@infthink.com
