### PR TITLE
Fix wifi tethering failed issue

### DIFF
--- a/dom/wifi/WifiWorker.js
+++ b/dom/wifi/WifiWorker.js
@@ -1174,7 +1174,10 @@ var WifiManager = (function() {
         // Driver startup on certain platforms takes longer than it takes
         // for us to return from loadDriver, so wait 2 seconds before
         // turning on Wifi tethering.
-        createWaitForDriverReadyTimer(doStartWifiTethering);
+        //createWaitForDriverReadyTimer(doStartWifiTethering);
+
+        // We directly call tethering because the driver has already been loaded when boot up. Let's monitor it.
+        doStartWifiTethering();
       });
     } else {
       cancelWifiHotspotStatusTimer();


### PR DESCRIPTION
Sometime wifi tethering failed because some wifi netdev's ioctls are called in bad time(when starting wifi tethering).
Frome the code, we now there's some delay time before starting wifi tethering, let's remove the delay and irectly call
tethering because the driver has already been loaded when boot up. Need monitor.

Signed-off-by: Jianmin Zhou toandrew@infthink.com
